### PR TITLE
Fix missing spotify_id handling in history

### DIFF
--- a/merge youtube Music likes into Spotify.py
+++ b/merge youtube Music likes into Spotify.py
@@ -137,7 +137,11 @@ def load_added_songs(added_songs_file):
             added_songs_list = json.load(f)
         successfully_added_songs = pd.DataFrame(added_songs_list)
     else:
-        successfully_added_songs = pd.DataFrame(columns=['title', 'artist', 'album'])
+        successfully_added_songs = pd.DataFrame(columns=['title', 'artist', 'album', 'spotify_id'])
+
+    if 'spotify_id' not in successfully_added_songs.columns:
+        successfully_added_songs['spotify_id'] = []
+
     return successfully_added_songs
 
 
@@ -464,6 +468,8 @@ def determine_best_matches(search_results):
 # %%
 def check_if_already_added(spotify_id, added_songs_df):
     """Check if a track with the given spotify_id is already in the added songs list."""
+    if 'spotify_id' not in added_songs_df.columns:
+        return False
     return spotify_id in added_songs_df['spotify_id'].values
 
 


### PR DESCRIPTION
## Summary
- ensure `load_added_songs` always has a `spotify_id` column
- guard `check_if_already_added` when column is missing

## Testing
- `python -m py_compile 'merge youtube Music likes into Spotify.py'`

------
https://chatgpt.com/codex/tasks/task_e_6883a16a8da083228e959474f25b9736