### PR TITLE
Ensure spotify_id tracked for added songs

### DIFF
--- a/merge youtube Music likes into Spotify.py
+++ b/merge youtube Music likes into Spotify.py
@@ -132,15 +132,28 @@ def read_or_fetch_spotify_likes(sp, file_path='data/spotify_likes.json'):
 # %%
 # Load previously added songs from JSON file if it exists
 def load_added_songs(added_songs_file):
+    """Load songs that were successfully added in previous runs.
+
+    Ensures the returned DataFrame always contains the columns
+    ``title``, ``artist``, ``album`` and ``spotify_id`` so that other
+    functions can rely on their presence.  When the JSON file does not
+    exist, an empty DataFrame with these columns is returned.
+    """
+
+    required_columns = ['title', 'artist', 'album', 'spotify_id']
+
     if os.path.exists(added_songs_file):
-        with open(added_songs_file, 'r') as f:
+        with open(added_songs_file, 'r', encoding='utf-8') as f:
             added_songs_list = json.load(f)
         successfully_added_songs = pd.DataFrame(added_songs_list)
-    else:
-        successfully_added_songs = pd.DataFrame(columns=['title', 'artist', 'album', 'spotify_id'])
 
-    if 'spotify_id' not in successfully_added_songs.columns:
-        successfully_added_songs['spotify_id'] = []
+        # Ensure all required columns are present even if the JSON file is
+        # missing some of them.
+        for col in required_columns:
+            if col not in successfully_added_songs.columns:
+                successfully_added_songs[col] = []
+    else:
+        successfully_added_songs = pd.DataFrame(columns=required_columns)
 
     return successfully_added_songs
 


### PR DESCRIPTION
## Summary
- Guarantee `load_added_songs` always returns DataFrame with `spotify_id`
- Add column repair when reading past runs to ensure consistency

## Testing
- `python -m py_compile "merge youtube Music likes into Spotify.py"`
- `python - <<'PY'
import ast, pandas as pd, json, os
file_path = 'merge youtube Music likes into Spotify.py'
with open(file_path, 'r', encoding='utf-8') as f:
    source = f.read()
module = ast.parse(source, filename=file_path)
funcs = {node.name: node for node in module.body if isinstance(node, ast.FunctionDef)}
namespace = {'pd': pd, 'json': json, 'os': os}
for name in ['load_added_songs', 'check_if_already_added']:
    func_node = funcs[name]
    code = compile(ast.Module(body=[func_node], type_ignores=[]), filename=file_path, mode='exec')
    exec(code, namespace)
load_added_songs = namespace['load_added_songs']
check_if_already_added = namespace['check_if_already_added']

nonexistent_file = 'added_songs_does_not_exist.json'
if os.path.exists(nonexistent_file):
    os.remove(nonexistent_file)

df = load_added_songs(nonexistent_file)
print('DataFrame columns:', df.columns.tolist())
print('DataFrame row count:', len(df))
print('Check existing id returns:', check_if_already_added('some_id', df))
PY`

------
https://chatgpt.com/codex/tasks/task_e_688e6d72935c8322822af9f3e33f3fc9